### PR TITLE
fnmatch() as a versions filter; in favour of #24

### DIFF
--- a/crosspm/api.py
+++ b/crosspm/api.py
@@ -26,6 +26,7 @@
 import sys
 import os
 import collections
+import fnmatch
 
 from crosspm.helpers import pm_common
 from crosspm.helpers import pm_download_output
@@ -534,15 +535,7 @@ class CrosspmPromoter:
 
             libs = data_tree[ d_name ][ d_branch ]
 
-
-            def version_filter_fn( v ):
-
-                lambda_f = lambda pair: pair[0] == '*' or int(pair[0]) == pair[1]
-
-                return all( map( lambda_f, zip( d_version, v[ 1 ] )))
-
-
-            versions = list( filter( version_filter_fn, libs ))
+            versions = [v for v in libs if fnmatch.fnmatch(v[0], '.'.join(d_version))]
 
             if not versions:
 

--- a/crosspm/helpers/pm_common.py
+++ b/crosspm/helpers/pm_common.py
@@ -93,9 +93,6 @@ def getPackageParams(i, line):
         warning( 'Error: wrong syntax at line {}. File: [{}]'.format( i, filepath ) )
         sys.exit( CMAKEPM_ERRORCODE_WRONGSYNTAX )
 
-    if parts[ 1 ] == '*':
-        parts[ 1 ] = '*.*.*.*'
-
     name    = parts[ 0 ]
     version = tuple( parts[ 1 ].split( '.' ) )
     branch  = parts[ 2 ] if n == 3 else 'master'


### PR DESCRIPTION
How about treating versions as strings and using fnmatch() as a filter for them?

This works correctly with such user patterns like `a.b.c`, `a.*.c`, etc. Suppose we search filenames.