### PR TITLE
fail Travis build if tests fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,10 +21,12 @@ before_script:
 before_deploy:
 - GH_TOKEN="$(cat $GH_TOKEN_FILE)"
 script:
+- set -e
 - flake8 crosspm
 - coverage run -m py.test tests
 - coverage xml
 - if [[ ! $CODACY_PROJECT_TOKEN ]]; then echo "Variable CODACY_PROJECT_TOKEN not set. Step is skipped."; exit 0; else python-codacy-coverage -r coverage.xml; fi
+- set +e
 deploy:
   provider: pypi
   user: devopshq


### PR DESCRIPTION
Currently, due to a bug in Travis-CI, the build won't fail
unless the last command in the script directive fails.

This means that if the lint or tests or coverage fail, the
Travis CI build itself won't fail, in turn giving the false
sense that everything is OK and the PR can be merged.

In order to work around this Travis CI limitation we need
to explicitly ask for the shell to exit with an error
immediately if a command exits with a non-zero status.
(set -e)
