### PR TITLE
Fix version of urllib3 same as at requests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,7 @@ setup(
     ],
     install_requires=[
         'requests',
-        'urllib3',
+        'urllib3<1.25,>=1.21.1',
         'docopt',
         'pyyaml',
         'dohq-artifactory',


### PR DESCRIPTION
Module "requests" set at  install_requires 'urllib3>=1.21.1,<1.25'
set same install_requires  at setup.py for crosspm
