### PR TITLE
Added bug fix with artifactory properties to merge it into master

### DIFF
--- a/crosspm/adapters/artifactoryaql.py
+++ b/crosspm/adapters/artifactoryaql.py
@@ -171,8 +171,9 @@ class Adapter(BaseAdapter):
                                 # Check if it's `root` packages or from `lock` file
                                 # ALSO, if from `lock` and have * in name - validate with property
                                 property_validate_tmp = property_validate or '*' in _file_name_pattern
+                                property_found = 'properties' in _found.keys()
                                 # If have not rule in config, skip this part
-                                if parser.has_rule('properties') and property_validate_tmp:
+                                if parser.has_rule('properties') and property_validate_tmp and property_found:
                                     _found_properties = {x['key']: x.get('value', '') for x in _found['properties']}
                                     _valid, _params = parser.validate(_found_properties, 'properties', _tmp_params,
                                                                       return_params=True)


### PR DESCRIPTION
**Description:** Fixed bug in handling empty artifactory properties. It led to the next error:
```shell
'properties'
Traceback (most recent call last):
  File "D:\ProgramFiles\Python38\lib\site-packages\crosspm\cpm.py", line 69, in wrapper
    res = func(self, *args, **kwargs)
  File "D:\ProgramFiles\Python38\lib\site-packages\crosspm\cpm.py", line 382, in command
    cpm_.entrypoint()
  File "D:\ProgramFiles\Python38\lib\site-packages\crosspm\helpers\downloader.py", line 160, in entrypoint
    self.download_packages(*args, **kwargs)
  File "D:\ProgramFiles\Python38\lib\site-packages\crosspm\helpers\downloader.py", line 135, in download_packages
    self.search_dependencies(depslock_file_path, deps_content=deps_content)
  File "D:\ProgramFiles\Python38\lib\site-packages\crosspm\helpers\downloader.py", line 164, in search_dependencies
    self._root_package.find_dependencies(depslock_file_path, property_validate=True, deps_content=deps_content, )
  File "D:\ProgramFiles\Python38\lib\site-packages\crosspm\helpers\package.py", line 116, in find_dependencies
    self.packages = self._downloader.get_dependency_packages({'raw': self._raw},
  File "D:\ProgramFiles\Python38\lib\site-packages\crosspm\helpers\downloader.py", line 77, in get_dependency_packages
    _found_packages = _src.get_packages(self, list_or_file_path, property_validate)
  File "D:\ProgramFiles\Python38\lib\site-packages\crosspm\helpers\source.py", line 20, in get_packages
    return self._adapter.get_packages(self, self._parser, downloader, list_or_file_path, property_validate)
  File "D:\ProgramFiles\Python38\lib\site-packages\crosspm\adapters\artifactoryaql.py", line 169, in get_packages
    _found_properties = {x['key']: x.get('value', '') for x in _found['properties']}
KeyError: 'properties'
Unknown error occurred!
```
