### PR TITLE
Update pyunpack for setuptools>=58 compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ dohq-artifactory>=0.7.377; python_version >= '3.5'
 Jinja2<2.11; python_version < '3.5'
 Jinja2>=2.11; python_version >= '3.5'
 patool==1.12
-pyunpack==0.1.2
+pyunpack==0.2
 PyYAML<5.2; python_version < '3.5'
 PyYAML>=5.2; python_version >= '3.5'
 requests<2.22; python_version < '3.5'

--- a/setup.py
+++ b/setup.py
@@ -95,7 +95,7 @@ setup(
         "Jinja2<2.11; python_version < '3.5'",
         "Jinja2>=2.11; python_version >= '3.5'",
         'patool==1.12',  # need for pyunpack
-        'pyunpack==0.1.2',
+        'pyunpack==0.2',
         # 'pyopenssl>=16.2.0',
         # 'cryptography>=1.7',
     ],


### PR DESCRIPTION
## Update Reason

pyunpack uses use_2to3 in it's setup.py

setuptools>=58 (bundled with virtualenv>=20.8.0) **does not support use_2to3 function** (see Breaking Changes [here](https://setuptools.pypa.io/en/latest/history.html#v58-0-0))