### PR TITLE
CM-61593 fixed create lock file

### DIFF
--- a/crosspm/helpers/downloader.py
+++ b/crosspm/helpers/downloader.py
@@ -122,17 +122,17 @@ class Downloader(Command):
 
     # Download packages or just unpack already loaded (it's up to adapter to decide)
     def download_packages(self, depslock_file_path=None):
+        deps_content = self._deps_path if isinstance(self._deps_path, DependenciesContent) else None
         if depslock_file_path is None:
             depslock_file_path = self._depslock_path
         if depslock_file_path.__class__ is DependenciesContent:
             # HACK для возможности проставления контента файла, а не пути
             pass
         elif isinstance(depslock_file_path, str):
-            if not os.path.isfile(depslock_file_path):
-                depslock_file_path = self._deps_path
-
-        deps_content = self._deps_path if isinstance(self._deps_path, DependenciesContent) else None
-        self.search_dependencies(depslock_file_path, deps_content=deps_content)
+            if os.path.isfile(depslock_file_path):
+                self.search_dependencies(depslock_file_path, deps_content=deps_content)
+            else:
+                self.search_dependencies(self._deps_path, deps_content=deps_content)
 
         if self.do_load:
             self._log.info('Unpack ...')
@@ -149,10 +149,7 @@ class Downloader(Command):
 
             if self._config.lock_on_success:
                 from crosspm.helpers.locker import Locker
-                depslock_path = os.path.realpath(
-                    os.path.join(os.path.dirname(depslock_file_path), self._config.deps_lock_file_name))
-                Locker(self._config, do_load=self.do_load, recursive=self.recursive).lock_packages(
-                    depslock_file_path, depslock_path, packages=self._root_package.packages)
+                Locker(self._config, do_load=self.do_load, recursive=self.recursive).lock_packages()
 
         return self._root_package.all_packages
 

--- a/crosspm/helpers/locker.py
+++ b/crosspm/helpers/locker.py
@@ -24,31 +24,19 @@ class Locker(Downloader):
             deps_path = config.deps_path.strip().strip('"').strip("'")
             self._deps_path = os.path.realpath(os.path.expanduser(deps_path))
 
-    def lock_packages(self, deps_file_path=None, depslock_file_path=None, packages=None):
+    def lock_packages(self):
         """
         Lock packages. Downloader search packages
         """
-        if deps_file_path is None:
-            deps_file_path = self._deps_path
-        if depslock_file_path is None:
-            depslock_file_path = self._depslock_path
-        if deps_file_path == depslock_file_path:
-            depslock_file_path += '.lock'
-            # raise CrosspmException(
-            #     CROSSPM_ERRORCODE_WRONG_ARGS,
-            #     'Dependencies and Lock files are same: "{}".'.format(deps_file_path),
-            # )
 
-        if packages is None:
-            self.search_dependencies(deps_file_path)
-        else:
-            self._root_package.packages = packages
+        if len(self._root_package.packages) == 0:
+            self.search_dependencies(self._deps_path)
 
-        self._log.info('Writing lock file [{}]'.format(depslock_file_path))
+        self._log.info('Writing lock file [{}]'.format(self._depslock_path))
 
         output_params = {
             'out_format': 'lock',
-            'output': depslock_file_path,
+            'output': self._depslock_path,
         }
         Output(config=self._config).write_output(output_params, self._root_package.packages)
         self._log.info('Done!')


### PR DESCRIPTION
Fixed the creation logic .lock file. The path to this file is defined in the crosspm configuration file or is overridden by passing the `--depslock-path` parameter in the console.

@antonzolotukhin @vasokot @sseuzss 
