### PR TITLE
Make `deps-path` and `depslock-path` arguments handling more predicta…

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -21,6 +21,7 @@ jobs:
           - '3.7'
           - '3.8'
           - '3.9'
+          - '3.10'
 
     steps:
       - uses: actions/checkout@v1

--- a/crosspm/adapters/artifactoryaql.py
+++ b/crosspm/adapters/artifactoryaql.py
@@ -13,6 +13,8 @@ from requests.auth import HTTPBasicAuth
 from crosspm.adapters.common import BaseAdapter
 from crosspm.helpers.exceptions import *  # noqa
 from crosspm.helpers.package import Package
+from crosspm.helpers.config import CROSSPM_DEPENDENCY_LOCK_FILENAME
+
 
 CHUNK_SIZE = 1024
 
@@ -271,6 +273,8 @@ class Adapter(BaseAdapter):
                 if downloader.do_load:
                     _package.download()
                     _deps_file = _package.get_file(self._config.deps_lock_file_name)
+                    if not _deps_file:
+                        _deps_file = _package.get_file(CROSSPM_DEPENDENCY_LOCK_FILENAME)
                     if downloader.recursive:
                         if _deps_file:
                             _package.find_dependencies(_deps_file, property_validate=False)

--- a/crosspm/adapters/common.py
+++ b/crosspm/adapters/common.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
 import logging
+from crosspm.helpers.config import Config
 
 
 class BaseAdapter:
-    def __init__(self, config):
+    def __init__(self, config: Config):
         self._config = config
         self._log = logging.getLogger('crosspm')
 

--- a/crosspm/adapters/files.py
+++ b/crosspm/adapters/files.py
@@ -5,6 +5,7 @@ import pathlib
 from crosspm.adapters.common import BaseAdapter
 from crosspm.helpers.exceptions import *  # noqa
 from crosspm.helpers.package import Package
+from crosspm.helpers.config import CROSSPM_DEPENDENCY_LOCK_FILENAME
 import os
 
 CHUNK_SIZE = 1024
@@ -208,8 +209,9 @@ class Adapter(BaseAdapter):
             if _added and (_package is not None):
                 if downloader.do_load:
                     _package.download()
-
                     _deps_file = _package.get_file(self._config.deps_lock_file_name)
+                    if not _deps_file:
+                        _deps_file = _package.get_file(CROSSPM_DEPENDENCY_LOCK_FILENAME)
                     if _deps_file:
                         _package.find_dependencies(_deps_file)
                     elif self._config.deps_file_name:

--- a/crosspm/cpm.py
+++ b/crosspm/cpm.py
@@ -199,11 +199,11 @@ class CrossPM:
     def read_config(self):
         _deps_path = self._args['--deps-path']
         # Передаём содержимое напрямую
-        if _deps_path is None and self._args['--dependencies-content'] is not None:
-            _deps_path = DependenciesContent(self._args['--dependencies-content'])
+        _deps_content = DependenciesContent(self._args['--dependencies-content']) \
+            if _deps_path is None and self._args['--dependencies-content'] is not None else None
         _depslock_path = self._args['--depslock-path']
-        if _depslock_path is None and self._args['--dependencies-lock-content'] is not None:
-            _depslock_path = DependenciesContent(self._args['--dependencies-lock-content'])
+        _depslock_content = DependenciesContent(self._args['--dependencies-lock-content']) \
+            if _depslock_path is None and self._args['--dependencies-lock-content'] is not None else None
         if self._args['lock']:
             if self._args['DEPS']:
                 _deps_path = self._args['DEPS']
@@ -211,7 +211,9 @@ class CrossPM:
                 _depslock_path = self._args['DEPSLOCK']
         self._config = Config(self._args['--config'], self._args['--options'], self._args['--no-fails'], _depslock_path,
                               _deps_path, self._args['--lock-on-success'],
-                              self._args['--prefer-local'])
+                              self._args['--prefer-local'],
+                              deps_content=_deps_content,
+                              deps_lock_content=_depslock_content)
         self._output = Output(self._config.output('result', None), self._config.name_column, self._config)
 
     def exit(self, code, msg):

--- a/crosspm/helpers/config.py
+++ b/crosspm/helpers/config.py
@@ -9,12 +9,11 @@ import requests
 import yaml
 
 from crosspm.helpers.cache import Cache
-from crosspm.helpers.content import DependenciesContent
 from crosspm.helpers.exceptions import *
 from crosspm.helpers.parser import Parser
 from crosspm.helpers.source import Source
 
-requests.packages.urllib3.disable_warnings()
+requests.packages.urllib3.disable_warnings()  # noqa
 
 WINDOWS = (platform.system().lower() == 'windows') or (os.name == 'nt')
 DEFAULT_CONFIG_FILE = ('crosspm.yaml', 'crosspm.yml', 'crosspm.json',)
@@ -44,16 +43,18 @@ GLOBAL_CONFIG_PATH = [
 
 ENVIRONMENT_CONFIG_PATH = 'CROSSPM_CONFIG_PATH'
 CROSSPM_DEPENDENCY_FILENAME = 'dependencies.txt'  # maybe 'cpm.manifest'
-CROSSPM_DEPENDENCY_LOCK_FILENAME = CROSSPM_DEPENDENCY_FILENAME  # 'dependencies.txt.lock'
+CROSSPM_DEPENDENCY_LOCK_FILENAME = CROSSPM_DEPENDENCY_FILENAME + ".lock"  # 'dependencies.txt.lock'
 CROSSPM_ADAPTERS_NAME = 'adapters'
 CROSSPM_ADAPTERS_DIR = os.path.join(CROSSPM_ROOT_DIR, CROSSPM_ADAPTERS_NAME)
 
 
 class Config:
     windows = WINDOWS
+    default_deps_file_name = CROSSPM_DEPENDENCY_FILENAME
+    default_deps_lock_file_name = CROSSPM_DEPENDENCY_LOCK_FILENAME
 
-    def __init__(self, config_file_name='', cmdline='', no_fails=False, depslock_path='', deps_path='',
-                 lock_on_success=False, prefer_local=False):
+    def __init__(self, config_file_name='', cmdline='', no_fails=False, deps_lock_file_path='', deps_file_path='',
+                 lock_on_success=False, prefer_local=False, deps_content=None, deps_lock_content=None):
         self._log = logging.getLogger('crosspm')
         self._config_path_env = []
         self._sources = []
@@ -70,46 +71,42 @@ class Config:
         self.name_column = ''
         self.deps_file_name = ''
         self.deps_lock_file_name = ''
+        self.deps_file_path = ''
+        self.deps_lock_file_path = ''
         self.lock_on_success = lock_on_success
         self.prefer_local = prefer_local
         self.crosspm_cache_root = ''
-        self.deps_path = ''
-        self.depslock_path = ''
+        self.deps_content = deps_content
+        self.deps_lock_content = deps_lock_content
+
         self.cache_config = {}
         self.init_env_config_path()
         self.secret_variables = []
 
         cpm_conf_name = ''
-        if deps_path:
-            if deps_path.__class__ is DependenciesContent:
-                # HACK
-                self.deps_path = deps_path
-            else:
-                deps_path = deps_path.strip().strip('"').strip("'")
-                self.deps_path = os.path.realpath(os.path.expanduser(deps_path))
+
+        if deps_file_path:
+            self.deps_file_path = self._normalize_path(deps_file_path)
             if not cpm_conf_name:
-                cpm_conf_name = self.get_cpm_conf_name(deps_path)
-            if os.path.isfile(deps_path):
-                config_path_tmp = os.path.dirname(deps_path)
+                cpm_conf_name = self.get_cpm_conf_name(self.deps_file_path)
+            if not os.path.isdir(self.deps_file_path):
+                config_path_tmp = os.path.dirname(self.deps_file_path)
             else:
-                config_path_tmp = deps_path
+                config_path_tmp = self.deps_file_path
+                self.deps_file_path = os.path.join(self.deps_file_path, CROSSPM_DEPENDENCY_FILENAME)
             if config_path_tmp not in DEFAULT_CONFIG_PATH:
                 DEFAULT_CONFIG_PATH.append(config_path_tmp)
+            self.deps_lock_file_path = self.deps_file_path + '.lock'
 
-        if depslock_path:
-            if depslock_path.__class__ is DependenciesContent:
-                # HACK
-                self.depslock_path = depslock_path
-            else:
-                depslock_path = depslock_path.strip().strip('"').strip("'")
-                self.depslock_path = os.path.realpath(os.path.expanduser(depslock_path))
-
+        if deps_lock_file_path:
+            self.deps_lock_file_path = self._normalize_path(deps_lock_file_path)
             if not cpm_conf_name:
-                cpm_conf_name = self.get_cpm_conf_name(depslock_path)
-            if os.path.isfile(depslock_path):
-                config_path_tmp = os.path.dirname(depslock_path)
+                cpm_conf_name = self.get_cpm_conf_name(self.deps_lock_file_path)
+            if not os.path.isdir(self.deps_lock_file_path):
+                config_path_tmp = os.path.dirname(self.deps_lock_file_path)
             else:
-                config_path_tmp = depslock_path
+                config_path_tmp = deps_lock_file_path
+                self.deps_lock_file_path = os.path.join(self.deps_lock_file_path, CROSSPM_DEPENDENCY_LOCK_FILENAME)
             if config_path_tmp not in DEFAULT_CONFIG_PATH:
                 DEFAULT_CONFIG_PATH.append(config_path_tmp)
 
@@ -145,9 +142,31 @@ class Config:
         self.cache = Cache(self, self.cache_config)
         # self._fails = {}
 
+    @property
+    def deps_file_name(self):
+        return os.path.basename(self.deps_file_path)
+
+    @property
+    def deps_lock_file_name(self):
+        return os.path.basename(self.deps_lock_file_path)
+
+    @deps_file_name.setter
+    def deps_file_name(self, file_name):
+        self.deps_file_path = self._normalize_path(file_name)
+
+    @deps_lock_file_name.setter
+    def deps_lock_file_name(self, file_name):
+        self.deps_lock_file_path = self._normalize_path(file_name)
+
+    @staticmethod
+    def _normalize_path(raw_path):
+        _path = raw_path.strip('"').strip("'")
+        _path = os.path.realpath(os.path.expanduser(_path))
+        return _path
+
     def get_cpm_conf_name(self, deps_filename=''):
         if not deps_filename:
-            deps_filename = self.depslock_path
+            deps_filename = self.deps_file_path
         result = ''
         if os.path.isfile(deps_filename):
             try:
@@ -525,11 +544,14 @@ class Config:
 
         crosspm = self.parse_options(crosspm, cmdline)
 
-        self.deps_lock_file_name = crosspm.get('dependencies-lock', CROSSPM_DEPENDENCY_LOCK_FILENAME)
-        if 'dependencies' in crosspm:
+        if not self.deps_file_name:
             self.deps_file_name = crosspm.get('dependencies', CROSSPM_DEPENDENCY_FILENAME)
-            if 'dependencies-lock' not in crosspm:
+        if not self.deps_lock_file_name:
+            self.deps_lock_file_name = crosspm.get('dependencies-lock', CROSSPM_DEPENDENCY_LOCK_FILENAME)
+            if 'dependencies-lock' not in crosspm and self.deps_file_name.endswith(".lock"):
                 self.deps_lock_file_name = self.deps_file_name
+            elif 'dependencies-lock' not in crosspm:
+                self.deps_lock_file_name = self.deps_file_name + ".lock"
 
         if not self.prefer_local:
             self.prefer_local = crosspm.get('prefer-local', False)

--- a/crosspm/helpers/locker.py
+++ b/crosspm/helpers/locker.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from typing import Optional, OrderedDict
+from typing import Optional, Dict
 from crosspm.helpers.package import Package
 from crosspm.helpers.downloader import Downloader
 from crosspm.helpers.output import Output
@@ -10,7 +10,7 @@ class Locker(Downloader):
         # TODO: revise logic to allow recursive search without downloading
         super(Locker, self).__init__(config, do_load, recursive)
 
-    def lock_packages(self, packages: Optional[OrderedDict[str, Package]] = None):
+    def lock_packages(self, packages: Optional[Dict[str, Package]] = None):
         """
         Lock packages. Downloader search packages
         """

--- a/crosspm/helpers/locker.py
+++ b/crosspm/helpers/locker.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
-import os
-
-from crosspm.helpers.config import CROSSPM_DEPENDENCY_FILENAME
-from crosspm.helpers.content import DependenciesContent
+from typing import Optional, OrderedDict
+from crosspm.helpers.package import Package
 from crosspm.helpers.downloader import Downloader
 from crosspm.helpers.output import Output
 
@@ -12,31 +10,20 @@ class Locker(Downloader):
         # TODO: revise logic to allow recursive search without downloading
         super(Locker, self).__init__(config, do_load, recursive)
 
-        if not getattr(config, 'deps_path', ''):
-            config.deps_path = config.deps_file_name or CROSSPM_DEPENDENCY_FILENAME
-
-        deps_path = config.deps_path
-        if deps_path.__class__ is DependenciesContent:
-            # HACK
-            pass
-            self._deps_path = deps_path
-        else:
-            deps_path = config.deps_path.strip().strip('"').strip("'")
-            self._deps_path = os.path.realpath(os.path.expanduser(deps_path))
-
-    def lock_packages(self):
+    def lock_packages(self, packages: Optional[OrderedDict[str, Package]] = None):
         """
         Lock packages. Downloader search packages
         """
 
-        if len(self._root_package.packages) == 0:
-            self.search_dependencies(self._deps_path)
+        if packages:
+            self._root_package.packages = packages
 
-        self._log.info('Writing lock file [{}]'.format(self._depslock_path))
+        if len(self._root_package.packages) == 0:
+            self.search_dependencies(self._config.deps_file_path, self._config.deps_content)
 
         output_params = {
             'out_format': 'lock',
-            'output': self._depslock_path,
+            'output': self._config.deps_lock_file_path,
         }
         Output(config=self._config).write_output(output_params, self._root_package.packages)
         self._log.info('Done!')

--- a/crosspm/helpers/output.py
+++ b/crosspm/helpers/output.py
@@ -218,10 +218,9 @@ class Output:
         if result:
             out_file_path = os.path.realpath(os.path.expanduser(params['output']))
             self.write_to_file(result, out_file_path)
+            msg = 'Writing lock file' if params['out_format'] == 'lock' else 'Write packages info to file'
             self._log.info(
-                'Write packages info to file [%s]\ncontent:\n\n%s',
-                out_file_path,
-                result,
+                f'{msg} {out_file_path}\ncontent:\n\n{result}',
             )
 
     def format_column(self, column, name, value):
@@ -399,7 +398,7 @@ class Output:
                 else:  # str
                     res += "{},\n".format(get_value(dict_or_list[item]))
             else:
-                res += '{} = '.format(self.get_var_name(item), get_value(dict_or_list[item]))
+                res += '{} = '.format(self.get_var_name(item))  # , get_value(dict_or_list[item]))
                 if isinstance(dict_or_list[item], dict):
                     res += '{\n'
                     for k, v in dict_or_list[item].items():

--- a/crosspm/helpers/package.py
+++ b/crosspm/helpers/package.py
@@ -4,7 +4,8 @@ import hashlib
 import logging
 import os
 import shutil
-from typing import OrderedDict
+from collections import OrderedDict
+from typing import Dict
 
 from artifactory import ArtifactoryPath
 
@@ -25,7 +26,7 @@ class Package:
         self.packed_path = ''
         self.unpacked_path = ''
         self.duplicated = False
-        self.packages: OrderedDict[str, Package] = OrderedDict()
+        self.packages: Dict[str, Package] = OrderedDict()
 
         self.pkg = pkg  # type: ArtifactoryPath
         # Someone use this internal object, do not remove  them :)

--- a/crosspm/helpers/package.py
+++ b/crosspm/helpers/package.py
@@ -4,7 +4,7 @@ import hashlib
 import logging
 import os
 import shutil
-from collections import OrderedDict
+from typing import OrderedDict
 
 from artifactory import ArtifactoryPath
 
@@ -25,7 +25,7 @@ class Package:
         self.packed_path = ''
         self.unpacked_path = ''
         self.duplicated = False
-        self.packages = OrderedDict()
+        self.packages: OrderedDict[str, Package] = OrderedDict()
 
         self.pkg = pkg  # type: ArtifactoryPath
         # Someone use this internal object, do not remove  them :)

--- a/crosspm/helpers/parser.py
+++ b/crosspm/helpers/parser.py
@@ -774,7 +774,7 @@ class Parser:
         return result
 
     def get_paths(self, list_or_file_path, source):
-        if 'path' not in self._rules:
+        if 'path' not in self._rules.keys():
             return None
         _paths = []
         for _params in self.iter_packages_params(list_or_file_path):
@@ -826,6 +826,7 @@ class Parser:
         return paths
 
     def iter_packages_params(self, list_or_file_path, deps_content=None):
+        # TODO: need to separate `list_or_file_path` into two arguments: `deps_path` and `deps_content`
         if deps_content is not None:
             # HACK for download with --dependencies-content and existed file dependencies.txt.lock
             list_or_file_path = deps_content

--- a/crosspm/helpers/promoter.py
+++ b/crosspm/helpers/promoter.py
@@ -26,8 +26,8 @@ class Promoter:
         self.temp_path = os.path.realpath(os.path.join(self._cache_path, 'tmp'))
 
         if not depslock_path:
-            depslock_path = config.deps_lock_file_name \
-                if config.deps_lock_file_name \
+            depslock_path = config.deps_lock_file_path \
+                if config.deps_lock_file_path \
                 else CROSSPM_DEPENDENCY_LOCK_FILENAME
         self._depslock_path = os.path.realpath(depslock_path)
 

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,5 +1,3 @@
 flake8==3.7.9
-pytest<=4.6.9; python_version < '3.5'
-pytest>=5.2; python_version >= '3.5'
-pytest-flask<1.0.0; python_version < '3.5'
-pytest-flask>=1.0.0; python_version >= '3.5'
+pytest>=5.2
+pytest-flask>=1.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ dohq-artifactory>=0.8.3
 Jinja2>=2.11
 patool==1.12
 pyunpack==0.2
-PyYAML>=5.2
-requests>=2.27.1
-urllib3==1.24.3
+PyYAML>=5.2,<6.0
+requests>=2.25.1,<3.0.0
+urllib3<1.25,>=1.21.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,8 @@
 docopt==0.6.2
-dohq-artifactory==0.4.112; python_version < '3.5'
-dohq-artifactory>=0.7.377; python_version >= '3.5'
-Jinja2<2.11; python_version < '3.5'
-Jinja2>=2.11; python_version >= '3.5'
+dohq-artifactory>=0.8.3
+Jinja2>=2.11
 patool==1.12
 pyunpack==0.2
-PyYAML<5.2; python_version < '3.5'
-PyYAML>=5.2; python_version >= '3.5'
-requests<2.22; python_version < '3.5'
-requests>=2.22; python_version >= '3.5'
+PyYAML>=5.2
+requests>=2.27.1
 urllib3==1.24.3

--- a/setup.py
+++ b/setup.py
@@ -78,10 +78,10 @@ setup(
         "PyYAML>=5.2",
     ],
     install_requires=[
-        "requests>=2.27.1",
-        'urllib3==1.24.3',
+        "requests>=2.25.1,<3.0.0",
+        'urllib3<1.25,>=1.21.1',
         'docopt==0.6.2',
-        "PyYAML>=5.2",
+        "PyYAML>=5.2,<6.0",
         "dohq-artifactory>=0.8.3",
         "Jinja2>=2.11",
         'patool==1.12',  # need for pyunpack

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 import os
-
 from setuptools import setup
-
 from crosspm import config
 
 build_number = os.getenv('GITHUB_RUN_NUMBER', '0')
@@ -43,6 +41,7 @@ setup(
     long_description=long_description,
     download_url='https://github.com/devopshq/crosspm.git',
     entry_points={'console_scripts': ['crosspm=crosspm.__main__:main']},
+    python_requires='>=3.6.0',
     classifiers=[
         'Development Status :: {}'.format(develop_status),
         'Environment :: Console',
@@ -51,12 +50,9 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Natural Language :: English',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.1',
-        'Programming Language :: Python :: 3.2',
-        'Programming Language :: Python :: 3.3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
     ],
     keywords=[
         'development',
@@ -77,24 +73,17 @@ setup(
         'pypandoc==1.5',
     ],
     tests_require=[
-        "pytest<=4.6.9; python_version < '3.5'",
-        "pytest>=5.2; python_version >= '3.5'",
-        "pytest-flask<1.0.0; python_version < '3.5'",
-        "pytest-flask>=1.0.0; python_version >= '3.5'",
-        "PyYAML<5.2; python_version < '3.5'",
-        "PyYAML>=5.2; python_version >= '3.5'",
+        "pytest>=5.2",
+        "pytest-flask>=1.0.0",
+        "PyYAML>=5.2",
     ],
     install_requires=[
-        "requests<2.22; python_version < '3.5'",
-        "requests>=2.22; python_version >= '3.5'",
+        "requests>=2.27.1",
         'urllib3==1.24.3',
         'docopt==0.6.2',
-        "PyYAML==5.1.2; python_version < '3.5'",
-        "PyYAML>=5.2; python_version >= '3.5'",
-        "dohq-artifactory==0.4.112; python_version < '3.5'",
-        "dohq-artifactory>=0.7.377; python_version >= '3.5'",
-        "Jinja2<2.11; python_version < '3.5'",
-        "Jinja2>=2.11; python_version >= '3.5'",
+        "PyYAML>=5.2",
+        "dohq-artifactory>=0.8.3",
+        "Jinja2>=2.11",
         'patool==1.12',  # need for pyunpack
         'pyunpack==0.2',
         # 'pyopenssl>=16.2.0',


### PR DESCRIPTION
- Made `--deps-path` and `--depslock-path` arguments handling more predictable:

    - CLI argument always overrides config parameters.
    - config.Config now is the single responsible for this behavior


- Got rid of double search when `--lock-on-success` in enabled
- Dropped python 3.5 support
- Update of requests and dohq_artifactory modules

