### PR TITLE
Disable recursion lock-file fallback if not found

### DIFF
--- a/crosspm/adapters/artifactoryaql.py
+++ b/crosspm/adapters/artifactoryaql.py
@@ -13,7 +13,6 @@ from requests.auth import HTTPBasicAuth
 from crosspm.adapters.common import BaseAdapter
 from crosspm.helpers.exceptions import *  # noqa
 from crosspm.helpers.package import Package
-from crosspm.helpers.config import CROSSPM_DEPENDENCY_LOCK_FILENAME
 
 
 CHUNK_SIZE = 1024

--- a/crosspm/adapters/artifactoryaql.py
+++ b/crosspm/adapters/artifactoryaql.py
@@ -273,8 +273,9 @@ class Adapter(BaseAdapter):
                 if downloader.do_load:
                     _package.download()
                     _deps_file = _package.get_file(self._config.deps_lock_file_name)
-                    if not _deps_file:
-                        _deps_file = _package.get_file(CROSSPM_DEPENDENCY_LOCK_FILENAME)
+                    # TODO: turn on this fallback after testing
+                    # if not _deps_file:
+                    #    _deps_file = _package.get_file(CROSSPM_DEPENDENCY_LOCK_FILENAME)
                     if downloader.recursive:
                         if _deps_file:
                             _package.find_dependencies(_deps_file, property_validate=False)

--- a/crosspm/adapters/files.py
+++ b/crosspm/adapters/files.py
@@ -210,8 +210,9 @@ class Adapter(BaseAdapter):
                 if downloader.do_load:
                     _package.download()
                     _deps_file = _package.get_file(self._config.deps_lock_file_name)
-                    if not _deps_file:
-                        _deps_file = _package.get_file(CROSSPM_DEPENDENCY_LOCK_FILENAME)
+                    # TODO: turn on this fallback after testing
+                    # if not _deps_file:
+                    #    _deps_file = _package.get_file(CROSSPM_DEPENDENCY_LOCK_FILENAME)
                     if _deps_file:
                         _package.find_dependencies(_deps_file)
                     elif self._config.deps_file_name:

--- a/crosspm/adapters/files.py
+++ b/crosspm/adapters/files.py
@@ -5,7 +5,6 @@ import pathlib
 from crosspm.adapters.common import BaseAdapter
 from crosspm.helpers.exceptions import *  # noqa
 from crosspm.helpers.package import Package
-from crosspm.helpers.config import CROSSPM_DEPENDENCY_LOCK_FILENAME
 import os
 
 CHUNK_SIZE = 1024

--- a/crosspm/helpers/config.py
+++ b/crosspm/helpers/config.py
@@ -50,8 +50,6 @@ CROSSPM_ADAPTERS_DIR = os.path.join(CROSSPM_ROOT_DIR, CROSSPM_ADAPTERS_NAME)
 
 class Config:
     windows = WINDOWS
-    default_deps_file_name = CROSSPM_DEPENDENCY_FILENAME
-    default_deps_lock_file_name = CROSSPM_DEPENDENCY_LOCK_FILENAME
 
     def __init__(self, config_file_name='', cmdline='', no_fails=False, deps_lock_file_path='', deps_file_path='',
                  lock_on_success=False, prefer_local=False, deps_content=None, deps_lock_content=None):


### PR DESCRIPTION
Some users wasn't expect that recursion is enabled by default. 
This mechanism allows recursive search even if depslock-file is not default. But this wasn't expected.


FYI @vasokot @kirg0 @sseuzss 